### PR TITLE
Rework header cleaning

### DIFF
--- a/spec/sentry/sanitizer/cleaner_spec.rb
+++ b/spec/sentry/sanitizer/cleaner_spec.rb
@@ -24,13 +24,14 @@ RSpec.describe Sentry::Sanitizer::Cleaner do
         'HTTP_H-1' => 'secret1',
         'HTTP_H-2' => 'secret2',
         'HTTP_H-3' => 'secret3',
+        'HTTP_AUTHORIZATION' => 'token',
+        'HTTP_X_XSRF_TOKEN' => 'xsrf=token',
         ::Rack::RACK_REQUEST_COOKIE_HASH => {
           'cookie1' => 'wooo',
           'cookie2' => 'weee',
           'cookie3' => 'WoWoW'
         }
-      })
-    )
+      }))
 
     Sentry.get_current_scope.apply_to_event(event)
   end
@@ -66,7 +67,9 @@ RSpec.describe Sentry::Sanitizer::Cleaner do
           'headers' => a_hash_including(
             'H-1' => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
             'H-2' => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
-            'H-3' => 'secret3'
+            'H-3' => 'secret3',
+            'Authorization' => 'token',
+            'X-Xsrf-Token' => 'xsrf=token'
           ),
           'cookies' => a_hash_including(
             'cookie1' => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
@@ -104,7 +107,9 @@ RSpec.describe Sentry::Sanitizer::Cleaner do
           :headers => a_hash_including(
             'H-1' => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
             'H-2' => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
-            'H-3' => 'secret3'
+            'H-3' => 'secret3',
+            'Authorization' => 'token',
+            'X-Xsrf-Token' => 'xsrf=token'
           ),
           :cookies => a_hash_including(
             'cookie1' => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
@@ -138,7 +143,9 @@ RSpec.describe Sentry::Sanitizer::Cleaner do
       expect(event.request.headers).to match a_hash_including(
         'H-1' => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
         'H-2' => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
-        'H-3' => 'secret3'
+        'H-3' => 'secret3',
+        'Authorization' => 'token',
+        'X-Xsrf-Token' => 'xsrf=token'
       )
       expect(event.request.cookies).to match a_hash_including(
         'cookie1' => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
@@ -148,6 +155,67 @@ RSpec.describe Sentry::Sanitizer::Cleaner do
       expect(event.extra).to match a_hash_including(
         :password => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
         :not_password => 'NOT SECRET'
+      )
+    end
+  end
+
+  context 'cleaning all headers' do
+    it 'filters everything according to configuration' do
+      Sentry.get_current_client.configuration.sanitize.http_headers = true
+      subject.call(event)
+
+      expect(event.request.headers).to match a_hash_including(
+        'H-1' => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
+        'H-2' => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
+        'H-3' => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
+        'Authorization' => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
+        'X-Xsrf-Token' => Sentry::Sanitizer::Cleaner::DEFAULT_MASK
+      )
+    end
+  end
+
+  context 'without configuration' do
+    before do
+      Sentry.get_current_client.configuration.instance_eval do
+        @sanitize = Sentry::Sanitizer::Configuration.new
+      end
+    end
+
+    it 'should not filter anything' do
+      event_h = event.to_hash
+      subject.call(event_h)
+
+      expect(event_h).to match a_hash_including(
+        :request => a_hash_including(
+          :data => a_hash_including(
+            'password' => 'SECRET',
+            'secret_token' => 'SECRET',
+            'oops' => 'OOPS',
+            'hmm' => [
+              a_hash_including(
+                'password' => 'SECRET',
+                'array' => 'too'
+              )
+            ]
+
+          ),
+          :headers => a_hash_including(
+            'H-1' => 'secret1',
+            'H-2' => 'secret2',
+            'H-3' => 'secret3',
+            'Authorization' => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
+            'X-Xsrf-Token' => Sentry::Sanitizer::Cleaner::DEFAULT_MASK
+          ),
+          :cookies => a_hash_including(
+            'cookie1' => 'wooo',
+            'cookie2' => 'weee',
+            'cookie3' => 'WoWoW'
+          )
+        ),
+        :extra => a_hash_including(
+          :password => 'SECRET',
+          :not_password => 'NOT SECRET'
+        )
       )
     end
   end


### PR DESCRIPTION
While evaulating this gem I realized that it crashes in the before_send callback unless http_headers is configured with an Array (setting it to `true` caused the same crash). This is very confusing as it can cause looping error reports in sentry.

In my efforts to fix that I realized that the header cleaning seemed to be a bit wider than expected, cleaning Authorization and X-Xsrf-Token even if custom http_headers configuration is assigned. This is not what the documentation described nor the tests asserted, so I assumed that was a mistake.

This pull request should fix both issues above while keeping the cleaning of Authorization and X-Xsrf-Token as a default behaviour. It seems reasonable to me, but should maybe be added to the readme.

Notice that I opted to inline the `sensitive_headers` method, as it can only be initialized properly if http_headers configuration is set to an array it seemed potentially confusing. The cost of rebuilding the regex for each exception should be negligible, as we don't expect to crash that many times.
