### PR TITLE
Bump sentry-ruby to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,8 @@
 
 ## Unreleased
 
+## (not released)
+- Update compatibility with sentry-rails 4.3 releases [#3](https://github.com/mrexox/sentry-sanitizer/pull/3)
+
 ## 0.2.1
 - Rework header cleaning to adhere to documentation in readme and not crash without configuration [#1](https://github.com/mrexox/sentry-sanitizer/pull/1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     sentry-sanitizer (0.2.1)
-      sentry-ruby (~> 4.2.0)
+      sentry-ruby (~> 4.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -34,11 +34,11 @@ GEM
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
     ruby2_keywords (0.0.4)
-    sentry-ruby (4.2.0)
+    sentry-ruby (4.3.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
-      sentry-ruby-core (= 4.2.0)
-    sentry-ruby-core (4.2.0)
+      sentry-ruby-core (= 4.3.0)
+    sentry-ruby-core (4.3.0)
       concurrent-ruby
       faraday
     simplecov (0.18.5)
@@ -59,4 +59,4 @@ DEPENDENCIES
   simplecov (~> 0.18.5)
 
 BUNDLED WITH
-   2.1.4
+   2.2.14

--- a/sentry-sanitizer.gemspec
+++ b/sentry-sanitizer.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rack'
 
-  spec.add_runtime_dependency 'sentry-ruby', '~> 4.2.0'
+  spec.add_runtime_dependency 'sentry-ruby', '~> 4.3.0'
 end


### PR DESCRIPTION
Basically bumping compitability to latest sentry-ruby version.

I've done some minimal testing (e.g. ran tests, and tried capturing an exception in rails console and in rails server with and without async handling).

I've however have not done any testing where i've tried to send data that should be filtered and ensure it's being filtered, can't really see anything in sentry-ruby [changelog](https://github.com/getsentry/sentry-ruby/blob/master/sentry-ruby/CHANGELOG.md) that indicates a change in data format though.
