### PR TITLE
Allow sentry-ruby ~> 5.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     sentry-sanitizer (0.5.0)
-      sentry-ruby (~> 5.3.0)
+      sentry-ruby (~> 5.3)
 
 GEM
   remote: https://rubygems.org/

--- a/sentry-sanitizer.gemspec
+++ b/sentry-sanitizer.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rack'
 
-  spec.add_runtime_dependency 'sentry-ruby', '~> 5.3.0'
+  spec.add_runtime_dependency 'sentry-ruby', '~> 5.3'
 end


### PR DESCRIPTION
Sentry has released 5.4.0 and 5.4.1 versions of sentry-ruby.  Relaxing the dependency to allow for >= 5.3 and < 6.0

https://github.com/getsentry/sentry-ruby/blob/master/CHANGELOG.md#540