### PR TITLE
fix: filter extra even without request

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   rspec:
     name: Unit tests
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
         include:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    concurrent-ruby (1.1.10)
+    bigdecimal (3.1.9)
+    concurrent-ruby (1.3.5)
     diff-lcs (1.5.0)
     docile (1.4.0)
     parallel (1.23.0)
@@ -44,7 +45,8 @@ GEM
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
-    sentry-ruby (5.4.1)
+    sentry-ruby (5.22.2)
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
     simplecov (0.18.5)
       docile (~> 1.1)

--- a/spec/sentry/sanitizer/cleaner_spec.rb
+++ b/spec/sentry/sanitizer/cleaner_spec.rb
@@ -15,6 +15,23 @@ RSpec.describe Sentry::Sanitizer::Cleaner do
     Sentry.configuration
   end
 
+  context "without a request" do
+    before do
+      Sentry.init do |config|
+        config.sanitize.fields = [:password]
+      end
+    end
+
+    it "clears extra fields" do
+      subject.call(event)
+
+      expect(event.extra).to match a_hash_including(
+        password: Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
+        not_password: "NOT SECRET"
+      )
+    end
+  end
+
   context "GET request" do
     before do
       Sentry.init do |config|

--- a/spec/sentry/sanitizer/cleaner_spec.rb
+++ b/spec/sentry/sanitizer/cleaner_spec.rb
@@ -233,6 +233,46 @@ RSpec.describe Sentry::Sanitizer::Cleaner do
           not_password: "NOT SECRET"
         )
       end
+
+      context "with Sentry::ErrorEvent" do
+        let(:event) do
+          Sentry::ErrorEvent.new(configuration: configuration).tap do |e|
+            e.extra = ({ password: "SECRET", not_password: "NOT SECRET" })
+          end
+        end
+
+        it "filters everything according to configuration" do
+          subject.call(event)
+
+          expect(event.request.data).to match a_hash_including(
+            "password" => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
+            "secret_token" => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
+            "oops" => "OOPS",
+            "hmm" => [
+              a_hash_including(
+                "password" => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
+                "array" => "too"
+              )
+            ]
+          )
+          expect(event.request.headers).to match a_hash_including(
+            "H-1" => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
+            "H-2" => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
+            "H-3" => "secret3",
+            "Authorization" => "token",
+            "X-Xsrf-Token" => "xsrf=token"
+          )
+          expect(event.request.cookies).to match a_hash_including(
+            "cookie1" => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
+            "cookie2" => Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
+            "cookie3" => Sentry::Sanitizer::Cleaner::DEFAULT_MASK
+          )
+          expect(event.extra).to match a_hash_including(
+            password: Sentry::Sanitizer::Cleaner::DEFAULT_MASK,
+            not_password: "NOT SECRET"
+          )
+        end
+      end
     end
 
     context "cleaning all headers" do


### PR DESCRIPTION
Closes https://github.com/mrexox/sentry-sanitizer/issues/13

**:wrench: Summary**

Sentry::ErrorEvent is a successor of Sentry::Event, so it must have the `request` field. But I noticed that current logic doesn't filter `extra` when there's no request given. So adding filtering `extra` event for empty `request`