### PR TITLE
Added guard to check breadcrumb data is a Hash object

### DIFF
--- a/lib/sentry/sanitizer/cleaner.rb
+++ b/lib/sentry/sanitizer/cleaner.rb
@@ -65,7 +65,7 @@ module Sentry
 
       def sanitize_breadcrumb!(breadcrumb)
         return unless breadcrumbs_json_data_fields.size.positive?
-        return unless breadcrumb.data
+        return unless breadcrumb.data.is_a? Hash
 
         breadcrumbs_json_data_fields.each do |field|
           next unless breadcrumb.data.key?(field)


### PR DESCRIPTION
Fix for https://github.com/mrexox/sentry-sanitizer/issues/21 as it appears that breadcrumb data in some instances can be something other than a `Hash`.

Also, while adding a spec for this I re-jigged the breadcrumb specs a bit to reduce some nesting. Happy to revert this and just put the spec in though if you think it isn't needed.